### PR TITLE
Use compatible `perf` instead of `performance`

### DIFF
--- a/js/timeit.js
+++ b/js/timeit.js
@@ -11,7 +11,7 @@ function start() {
 // finish stops measuring the execution time
 // and returns elasped time in ms
 function finish() {
-    var elapsed = performance.now() - started;
+    var elapsed = perf.now() - started;
     return Math.round(elapsed);
 }
 


### PR DESCRIPTION
I was just looking at the code and noticed this is probably a bug for older browsers without native `window.performance`. If I am wrong feel free to close the PR.