### PR TITLE
Fix spellcheck (minor annoyance)

### DIFF
--- a/js/components/sqlime-editor.js
+++ b/js/components/sqlime-editor.js
@@ -12,7 +12,7 @@ class SqlimeEditor extends HTMLElement {
 
     render() {
         this.contentEditable = "true";
-        this.spellcheck = "false";
+        this.spellcheck = false;
     }
 
     listen() {

--- a/js/components/sqlime-editor.js
+++ b/js/components/sqlime-editor.js
@@ -12,6 +12,7 @@ class SqlimeEditor extends HTMLElement {
 
     render() {
         this.contentEditable = "true";
+        this.spellcheck = "false";
     }
 
     listen() {


### PR DESCRIPTION
Fix spellcheck (minor annoyance); in MS Edge in its default config, it is more pronounced than anywhere else I've tried (its AI or whatever check handles grammar and shows double blue lines underneath).